### PR TITLE
[WIP] SOADataArray points

### DIFF
--- a/pvxarray/accessor.py
+++ b/pvxarray/accessor.py
@@ -227,7 +227,7 @@ class PyVistaStructuredGridAccessor(BasePyVistaAccessor):
 
     @property
     def points(self):
-        """Generate structured vtkPoints from seperately allocated arrays."""
+        """Generate structured vtkPoints from separately allocated arrays."""
         if self.z is None:
             zv = np.zeros_like(self.x).ravel(order="F")
         else:

--- a/pvxarray/utils.py
+++ b/pvxarray/utils.py
@@ -25,7 +25,7 @@ def soa(*arrays):
 
 
 def soa_points(x, y, z):
-    """Generate vtkPoints from 3 seperately allocated numpy arrays."""
+    """Generate vtkPoints from 3 separately allocated numpy arrays."""
     data = soa(x, y, z)
     points = vtk.vtkPoints()
     points.SetData(data)

--- a/pvxarray/utils.py
+++ b/pvxarray/utils.py
@@ -1,0 +1,32 @@
+import numpy as np
+import vtk
+from vtkmodules.util.numpy_support import numpy_to_vtk
+
+
+def soa(*arrays):
+    """Combine separately allocated numpy arrays into a VTK SOA array."""
+    if len(arrays) == 0:
+        raise ValueError("No arrays passed")
+    for i, arr in enumerate(arrays):
+        if not isinstance(arr, np.ndarray):
+            raise ValueError(f"argument {i} is not a numpy array")
+    if len({arr.dtype for arr in arrays}) != 1:
+        raise TypeError("All components must have the same dtype")
+    if len({arr.size for arr in arrays}) != 1:
+        raise TypeError("All components must have the same size")
+    if len({arr.ndim for arr in arrays}) != 1 or arrays[0].ndim != 1:
+        raise ValueError("Please ravel the input arrays")
+    data = vtk.vtkSOADataArrayTemplate[arrays[0].dtype]()
+    data.SetNumberOfComponents(len(arrays))
+    data.SetNumberOfValues(arrays[0].size)
+    for i, arr in enumerate(arrays):
+        data.SetArray(i, numpy_to_vtk(arr), arr.size, True, True)
+    return data
+
+
+def soa_points(x, y, z):
+    """Generate vtkPoints from 3 seperately allocated numpy arrays."""
+    data = soa(x, y, z)
+    points = vtk.vtkPoints()
+    points.SetData(data)
+    return points

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,13 @@
+import numpy as np
+import pytest
+
 import pvxarray  # noqa: F401
+
+
+@pytest.fixture
+def meshgrid():
+    x = np.arange(-10, 10, 0.25)
+    y = np.arange(-10, 10, 0.25)
+    x, y = np.meshgrid(x, y)
+    z = np.sin(np.sqrt(x**2 + y**2))
+    return x, y, z

--- a/tests/test_soa.py
+++ b/tests/test_soa.py
@@ -1,0 +1,54 @@
+import vtk
+from vtkmodules.util.numpy_support import vtk_to_numpy
+
+from pvxarray import utils
+
+# TODO: VTK_SILENCE_GET_VOID_POINTER_WARNINGS
+
+
+def _get_xyz_bounds(values):
+    return (
+        values[:, 0].min(),
+        values[:, 0].max(),
+        values[:, 1].min(),
+        values[:, 1].max(),
+        values[:, 2].min(),
+        values[:, 2].max(),
+    )
+
+
+def test_soa_values(meshgrid):
+    """Generate SOA array, check size and value bounds."""
+    x, y, z = meshgrid
+    bounds = (x.min(), x.max(), y.min(), y.max(), z.min(), z.max())
+    # Test standard SOA array
+    data = utils.soa(x.ravel(order="F"), y.ravel(order="F"), z.ravel(order="F"))
+    assert data.GetNumberOfValues() == x.size * 3
+    dvalues = vtk_to_numpy(data)
+    dbounds = _get_xyz_bounds(dvalues)
+    assert dbounds == bounds
+    # Test with vtkPoints
+    points = vtk.vtkPoints()
+    points.SetData(data)
+    assert points.GetNumberOfPoints() == x.size
+    pvalues = vtk_to_numpy(points.GetData())
+    pbounds = _get_xyz_bounds(pvalues)
+    assert pbounds == bounds
+
+
+def test_soa_structured_grid(meshgrid):
+    x, y, z = meshgrid
+    points = utils.soa_points(x.ravel(order="F"), y.ravel(order="F"), z.ravel(order="F"))
+
+    # Generate mesh
+    mesh = vtk.vtkStructuredGrid()
+    mesh.SetPoints(points)
+    mesh.SetDimensions((*x.shape, 1))
+
+    # Validate
+    assert mesh.GetNumberOfPoints() == x.size
+    assert mesh.GetBounds() == (x.min(), x.max(), y.min(), y.max(), z.min(), z.max())
+
+
+# def test_soa_modify_inplace(meshgrid):
+#     x, y, z = meshgrid

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -4,11 +4,8 @@ import xarray as xr
 
 
 @pytest.fixture
-def simple():
-    x = np.arange(-10, 10, 0.25)
-    y = np.arange(-10, 10, 0.25)
-    z = np.sin(np.sqrt(x**2 + y**2))
-    x, y, z = np.meshgrid(x, y, z)
+def simple(meshgrid):
+    x, y, z = meshgrid
     temp = 15 + 8 * np.random.randn(*x.shape)
 
     ds = xr.Dataset(

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -4,8 +4,11 @@ import xarray as xr
 
 
 @pytest.fixture
-def simple(meshgrid):
-    x, y, z = meshgrid
+def simple():
+    x = np.arange(-10, 10, 0.25)
+    y = np.arange(-10, 10, 0.25)
+    z = np.sin(np.sqrt(x**2 + y**2))
+    x, y, z = np.meshgrid(x, y, z)
     temp = 15 + 8 * np.random.randn(*x.shape)
 
     ds = xr.Dataset(

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -51,13 +51,13 @@ def test_simple(simple):
     assert np.array_equal(mesh["temperature"], simple["temp"].ravel(order="F"))
 
 
-@pytest.mark.xfail
-def test_shared_data(simple):
-    mesh = simple["ds"].temperature.pyvista_structured.mesh
-
-    mesh["temperature"][0] = -1
-    assert simple["temp"].ravel()[0] == -1
-    assert np.array_equal(mesh["temperature"], simple["temp"].ravel(order="F"))
+# @pytest.mark.xfail
+# def test_shared_data(simple):
+#     mesh = simple["ds"].temperature.pyvista_structured.mesh
+#
+#     mesh["temperature"][0] = -1
+#     assert simple["temp"].ravel()[0] == -1
+#     assert np.array_equal(mesh["temperature"], simple["temp"].ravel(order="F"))
 
 
 def test_roms(roms):


### PR DESCRIPTION
Resolves #9 

This utilizes `vtkSOADataArrayTemplate` to create a no-copy `vtkPoints` instance from structured points in separately allocated arrays (for `StructuredGrid`s/meshgrids)

There is a flaky test failure at the moment where the Z-component of the array is not always copied correctly.