### PR TITLE
Add cf conventions helper

### DIFF
--- a/pvxarray/accessor.py
+++ b/pvxarray/accessor.py
@@ -4,6 +4,7 @@ import pyvista as pv
 import xarray as xr
 
 from pvxarray import rectilinear, structured
+from pvxarray.cf import get_cf_names
 
 
 class _LocIndexer:
@@ -51,6 +52,13 @@ class PyVistaAccessor:
         order: Optional[str] = None,
         component: Optional[str] = None,
     ) -> pv.DataSet:
+        if (3 - (x, y, z).count(None)) < 1:
+            try:
+                x, y, z = get_cf_names(self._obj)
+            except ImportError:
+                raise ValueError(
+                    "You must specify at least one dimension as X, Y, or Z or install `cf_xarray`."
+                )
         ndim = 0
         if x is not None:
             _x = self._get_array(x)

--- a/pvxarray/cf.py
+++ b/pvxarray/cf.py
@@ -1,0 +1,12 @@
+def get_cf_names(da):
+    """Use `cf_xarray` to get the names of the X, Y, and Z arrays."""
+    try:
+        import cf_xarray  # noqa
+
+        axes = da.cf.axes
+    except (AttributeError, ImportError):
+        raise ImportError("Please import `cf_xarray` to use CF conventions.")
+    x = axes.get("X", [None])[0]
+    y = axes.get("Y", [None])[0]
+    z = axes.get("Z", [None])[0]
+    return x, y, z

--- a/tests/test_cf.py
+++ b/tests/test_cf.py
@@ -1,0 +1,17 @@
+import numpy as np
+import xarray as xr
+
+
+def test_air_temperature():
+    ds = xr.tutorial.load_dataset("air_temperature")
+    da = ds.air[dict(time=0)]
+
+    mesh = da.pyvista.mesh()  # No X,Y,Z specified, so should try cf_xarray
+    assert mesh
+    assert mesh.n_points == 1325
+    assert "air" in mesh.point_data
+
+    assert np.array_equal(mesh["air"], da.values.ravel())
+    assert np.may_share_memory(mesh["air"], da.values.ravel())
+    assert np.array_equal(mesh.x, da.lon)
+    assert np.array_equal(mesh.y, da.lat)


### PR DESCRIPTION
Resolves #15 

I feel this should be double-checked by someone more familiar with CF conventions and how that accessor works.

Also, this should be tested against more datasets

cc @rabernat, any feedback here? The premise is that the new function added here can attempt to use `cf_xarray` to get the XYZ coordinate array names when the user does not specify names.