### PR TITLE
Data slicing optimization for PyVistaXarraySource

### DIFF
--- a/pvxarray/vtk_source.py
+++ b/pvxarray/vtk_source.py
@@ -1,5 +1,5 @@
 import traceback
-from typing import Optional, List
+from typing import List, Optional
 
 import numpy as np
 import pyvista as pv

--- a/pvxarray/vtk_source.py
+++ b/pvxarray/vtk_source.py
@@ -272,7 +272,7 @@ time_index: {self._time_index}
         # Use open data_array handle to fetch data at
         # desired Level of Detail
         try:
-            if self.mesh is None:
+            if self.mesh is None or self.modified:
                 self.compute_mesh()
             pdo = self.GetOutputData(outInfo, 0)
             pdo.ShallowCopy(self.mesh)

--- a/pvxarray/vtk_source.py
+++ b/pvxarray/vtk_source.py
@@ -236,7 +236,7 @@ time_index: {self._time_index}
                     sliced_array = np.where(np.logical_and(c >= s[0], c <= s[1]))[0]
                     sliced_array = sliced_array[:: int(s[2])]
                     indexing[axis] = sliced_array
-            da = da[indexing]
+            da = da.isel(**indexing)
 
         elif self._resolution:
             rx, ry, rz = self.resolution_to_sampling_rate(da)

--- a/pvxarray/vtk_source.py
+++ b/pvxarray/vtk_source.py
@@ -1,5 +1,5 @@
 import traceback
-from typing import Optional
+from typing import Optional, List
 
 import numpy as np
 import pyvista as pv
@@ -189,7 +189,7 @@ time_index: {self._time_index}
         return self._slicing
 
     @slicing.setter
-    def slicing(self, slicing: int):
+    def slicing(self, slicing: Optional[List[int]]):
         self._slicing = slicing
         self.Modified()
 
@@ -243,7 +243,7 @@ time_index: {self._time_index}
                 self.y,
                 self.z,
             ]:
-                if axis in self.slicing:
+                if axis in self._slicing:
                     s = self._slicing[axis]
                     c = da.coords[axis]
                     sliced_array = np.where(np.logical_and(c >= s[0], c <= s[1]))[0]

--- a/pvxarray/vtk_source.py
+++ b/pvxarray/vtk_source.py
@@ -74,7 +74,6 @@ class PyVistaXarraySource(BaseSource):
         self._slicing = None
         self._sliced_data_array = None
         self._persisted_data = None
-        self._modified = False
         self._mesh = None
 
     def __str__(self):
@@ -196,7 +195,7 @@ time_index: {self._time_index}
 
     @property
     def sliced_data_array(self):
-        if self._sliced_data_array is None or self._modified:
+        if self._sliced_data_array is None:
             self._compute_sliced_data_array()
         return self._sliced_data_array
 
@@ -227,8 +226,6 @@ time_index: {self._time_index}
     def _compute_sliced_data_array(self):
         if self.data_array is None:
             self._sliced_data_array = None
-            self._modified = False
-            self._persisted_data = None
             return None
 
         if self._time is not None:
@@ -264,9 +261,6 @@ time_index: {self._time_index}
                 da = da[::rx, ::ry, ::rz]
 
         self._sliced_data_array = da
-        self._persisted_data = None
-        self._mesh = None
-        self._modified = False
         return self._sliced_data_array
 
     def _compute_mesh(self):
@@ -281,7 +275,9 @@ time_index: {self._time_index}
         return self._mesh
 
     def Modified(self, **kwargs):
-        self._modified = True
+        self._sliced_data_array = None
+        self._persisted_data = None
+        self._mesh = None
         super().Modified(**kwargs)
 
     def RequestData(self, request, inInfo, outInfo):


### PR DESCRIPTION
This PR adds functionality to `PyVistaXarraySource`, adding more specific slicing to its API and optimizing load times for remote datasets.

- `resolution` is now optional. `slicing` may be specified instead, which should be a dictionary mapping coordinate names to arrays. Each array should be structured as `[start, stop, step]`.
- The class now stores `_sliced_data_array`, which should only be computed once each time the inputs are modified. 
- The class now stores `_persisted_data`, which should only be computed once each time `_sliced_data_array` is changed. 
- The class now stores `_mesh`, which also should only be computed once each time `_persisted_data` is changed.
- The `RequestData` method no longer needs to compute the mesh every time if they are already stored, which greatly decreases total load time.

See https://github.com/Kitware/pan3d/pull/34 for application of these changes and load time testing.