### PR TITLE
Allow non-numeric coordinates (e.g. time) as spatial axes

### DIFF
--- a/pvxarray/accessor.py
+++ b/pvxarray/accessor.py
@@ -42,7 +42,7 @@ class PyVistaAccessor:
     def _get_array(self, key, scale=1):
         try:
             values = self._obj[key].values
-            if str(values.dtype) == "object":
+            if "float" not in str(values.dtype) and "int" not in str(values.dtype):
                 # non-numeric coordinate, assign array of scaled indices
                 values = np.array(range(len(values))) * scale
             return values

--- a/pvxarray/accessor.py
+++ b/pvxarray/accessor.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 import numpy as np
 import pyvista as pv
@@ -39,11 +39,12 @@ class PyVistaAccessor:
         """Attribute for location based indexing like pandas."""
         return _LocIndexer(self)
 
-    def _get_array(self, key):
+    def _get_array(self, key, scale=1):
         try:
             values = self._obj[key].values
             if str(values.dtype) == 'object':
-                values = np.array(range(len(values)))
+                # non-numeric coordinate, assign array of scaled indices
+                values = np.array(range(len(values))) * scale
             return values
         except KeyError:
             raise KeyError(
@@ -62,6 +63,7 @@ class PyVistaAccessor:
         order: Optional[str] = None,
         component: Optional[str] = None,
         mesh_type: Optional[str] = None,
+        scales: Optional[Dict] = None,
     ) -> pv.DataSet:
         ndim = 0
         if x is not None:
@@ -84,7 +86,7 @@ class PyVistaAccessor:
             meth = methods[mesh_type]
         except KeyError:
             raise KeyError
-        return meth(self, x=x, y=y, z=z, order=order, component=component)
+        return meth(self, x=x, y=y, z=z, order=order, component=component, scales=scales)
 
     def plot(
         self,

--- a/pvxarray/accessor.py
+++ b/pvxarray/accessor.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import numpy as np
 import pyvista as pv
 import xarray as xr
 
@@ -40,7 +41,10 @@ class PyVistaAccessor:
 
     def _get_array(self, key):
         try:
-            return self._obj[key].values
+            values = self._obj[key].values
+            if str(values.dtype) == 'object':
+                values = np.array(range(len(values)))
+            return values
         except KeyError:
             raise KeyError(
                 f"Key {key} not present in DataArray. Choices are: {list(self._obj.coords.keys())}"

--- a/pvxarray/accessor.py
+++ b/pvxarray/accessor.py
@@ -42,7 +42,7 @@ class PyVistaAccessor:
     def _get_array(self, key, scale=1):
         try:
             values = self._obj[key].values
-            if str(values.dtype) == 'object':
+            if str(values.dtype) == "object":
                 # non-numeric coordinate, assign array of scaled indices
                 values = np.array(range(len(values))) * scale
             return values

--- a/pvxarray/rectilinear.py
+++ b/pvxarray/rectilinear.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 import warnings
 
 import pyvista as pv
@@ -13,6 +13,7 @@ def mesh(
     z: Optional[str] = None,
     order: Optional[str] = "C",
     component: Optional[str] = None,
+    scales: Optional[Dict] = None,
 ):
     if order is None:
         order = "C"
@@ -22,11 +23,11 @@ def mesh(
         raise ValueError("You must specify at least one dimension as X, Y, or Z.")
     # Construct the mesh
     if x is not None:
-        self._mesh.x = self._get_array(x)
+        self._mesh.x = self._get_array(x, scale=(scales and scales.get(x)) or 1)
     if y is not None:
-        self._mesh.y = self._get_array(y)
+        self._mesh.y = self._get_array(y, scale=(scales and scales.get(y)) or 1)
     if z is not None:
-        self._mesh.z = self._get_array(z)
+        self._mesh.z = self._get_array(z, scale=(scales and scales.get(z)) or 1)
     # Handle data values
     values = self.data
     values_dim = values.ndim

--- a/pvxarray/structured.py
+++ b/pvxarray/structured.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 import warnings
 
 import numpy as np
@@ -41,6 +41,7 @@ def _points(
     y: Optional[str] = None,
     z: Optional[str] = None,
     order: Optional[str] = "F",
+    scales: Optional[Dict] = None,
 ):
     """Generate structured points as new array."""
     if order is None:
@@ -52,11 +53,11 @@ def _points(
             raise ValueError("One dimensional structured grids should be rectilinear grids.")
         raise ValueError("You must specify at least two dimensions as X, Y, or Z.")
     if x is not None:
-        x = self._get_array(x)
+        x = self._get_array(x, scale=(scales and scales.get(x)) or 1)
     if y is not None:
-        y = self._get_array(y)
+        y = self._get_array(y, scale=(scales and scales.get(y)) or 1)
     if z is not None:
-        z = self._get_array(z)
+        z = self._get_array(z, scale=(scales and scales.get(z)) or 1)
     arrs = _coerce_shapes(x, y, z)
     x, y, z = arrs
     arr = [a for a in arrs if a is not None][0]
@@ -78,6 +79,7 @@ def mesh(
     z: Optional[str] = None,
     order: str = "F",
     component: Optional[str] = None,  # TODO
+    scales: Optional[Dict] = None,
 ):
     if order is None:
         order = "F"
@@ -88,7 +90,7 @@ def mesh(
             "StructuredGrid accessor duplicates data - VTK/PyVista data not shared with xarray."
         )
     )
-    points, shape = _points(self, x=x, y=y, z=z, order=order)
+    points, shape = _points(self, x=x, y=y, z=z, order=order, scales=scales)
     self._mesh.points = points
     self._mesh.dimensions = shape
     data = self.data

--- a/pvxarray/vtk_source.py
+++ b/pvxarray/vtk_source.py
@@ -238,17 +238,9 @@ time_index: {self._time_index}
 
         if self._slicing:
             indexing = {}
-            for axis in [
-                self.x,
-                self.y,
-                self.z,
-            ]:
+            for axis in [self.x, self.y, self.z]:
                 if axis in self._slicing:
-                    s = self._slicing[axis]
-                    c = da.coords[axis]
-                    sliced_array = np.where(np.logical_and(c >= s[0], c <= s[1]))[0]
-                    sliced_array = sliced_array[:: int(s[2])]
-                    indexing[axis] = sliced_array
+                    indexing[axis] = slice(*[int(v) for v in self._slicing[axis]])
             da = da.isel(**indexing)
 
         elif self._resolution:

--- a/pvxarray/vtk_source.py
+++ b/pvxarray/vtk_source.py
@@ -263,6 +263,10 @@ time_index: {self._time_index}
             order=self._order,
             component=self._component,
             mesh_type=self._mesh_type,
+            scales = {
+                k: v[2]
+                for k, v in self._slicing.items()
+            }
         )
         return self._mesh
 

--- a/pvxarray/vtk_source.py
+++ b/pvxarray/vtk_source.py
@@ -263,10 +263,7 @@ time_index: {self._time_index}
             order=self._order,
             component=self._component,
             mesh_type=self._mesh_type,
-            scales = {
-                k: v[2]
-                for k, v in self._slicing.items()
-            }
+            scales={k: v[2] for k, v in self._slicing.items()},
         )
         return self._mesh
 

--- a/pvxarray/vtk_source.py
+++ b/pvxarray/vtk_source.py
@@ -228,22 +228,21 @@ time_index: {self._time_index}
             self._sliced_data_array = None
             return None
 
+        indexing = {}
+        if self._slicing is not None:
+            indexing = {
+                k: slice(*v) for k, v in self._slicing.items() if k in [self.x, self.y, self.z]
+            }
+
         if self._time is not None:
-            da = self.data_array[{self._time: self.time_index}]
-        else:
-            da = self.data_array
+            indexing.update(**{self._time: self.time_index})
 
-        if self._z and self._z_index is not None:
-            da = da[{self._z: self.z_index}]
+        if self.z and self.z_index is not None:
+            indexing.update(**{self.z: self.z_index})
 
-        if self._slicing:
-            indexing = {}
-            for axis in [self.x, self.y, self.z]:
-                if axis in self._slicing:
-                    indexing[axis] = slice(*[int(v) for v in self._slicing[axis]])
-            da = da.isel(**indexing)
+        da = self.data_array.isel(indexing)
 
-        elif self._resolution:
+        if self._slicing is None and self._resolution is not None:
             rx, ry, rz = self.resolution_to_sampling_rate(da)
             if da.ndim <= 1:
                 da = da[::rx]

--- a/pvxarray/vtk_source.py
+++ b/pvxarray/vtk_source.py
@@ -263,7 +263,7 @@ time_index: {self._time_index}
             order=self._order,
             component=self._component,
             mesh_type=self._mesh_type,
-            scales={k: v[2] for k, v in self._slicing.items()},
+            scales={k: v[2] for k, v in self._slicing.items()} if self._slicing else {},
         )
         return self._mesh
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -28,3 +28,44 @@ def test_vtk_source():
     source.resolution = 0.5
     mesh = source.apply()
     assert mesh.n_points < 1325
+
+
+def test_vtk_source_time_as_spatial():
+    ds = xr.tutorial.load_dataset("air_temperature")
+
+    da = ds.air
+    source = PyVistaXarraySource(da, x="lon", y="lat", z="time")
+
+    mesh = source.apply()
+    assert mesh
+    assert mesh.n_points == 3869000
+    assert "air" in mesh.point_data
+
+    assert np.array_equal(mesh["air"], da.values.ravel())
+    assert np.array_equal(mesh.x, da.lon)
+    assert np.array_equal(mesh.y, da.lat)
+    # Z values are indexes instead of datetime objects
+    assert np.array_equal(mesh.z, list(range(da.time.size)))
+
+
+def test_vtk_source_slicing():
+    ds = xr.tutorial.load_dataset("eraint_uvz")
+
+    da = ds.z
+    source = PyVistaXarraySource(
+        da,
+        x="longitude",
+        y="latitude",
+        z="level",
+        time="month",
+    )
+    source.time_index = 1
+    source.slicing = {
+        "latitude": [0, 241, 2],
+        "longitude": [0, 480, 4],
+        "level": [0, 3, 1],
+        "month": [0, 2, 1],  # should be ignored in favor of t_index
+    }
+
+    sliced = source.sliced_data_array
+    assert sliced.shape == (3, 121, 120)


### PR DESCRIPTION
This PR enables selecting coordinates with non-numeric dtypes for spatial axes. Since the true values of a non-numeric coordinate cannot be used on the mesh, a representative value list is created to use on the mesh. This representative list is similar to an index list, but it is scaled according to the `step` value used to slice that coordinate. 

For example, if a coordinate `time` is selected for the Z axis and a slicing of `[0, 20, 4]` is applied to `time`, then `mesh.z` will have the following values: `[0, 4, 8, 12, 16]` .

In order to be compatible with non-numeric coordinates, this PR also reorganizes how slicing is done. Expected values for slice arrays must refer to indexes rather than values in the coordinate array.