### PR TITLE
Fix vtk import

### DIFF
--- a/pvxarray/vtk_source.py
+++ b/pvxarray/vtk_source.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import numpy as np
 import pyvista as pv
-from vtk.util.vtkAlgorithm import VTKPythonAlgorithmBase
+from vtkmodules.util.vtkAlgorithm import VTKPythonAlgorithmBase
 import xarray as xr
 
 


### PR DESCRIPTION
When importing pvxarray on a system that does not have `libX11-6` installed (such as CI runners), the import can fail with the following error: `ImportError: libX11.so.6: cannot open shared object file: No such file or directory`. This is because we currently import `from vtk.util.vtkAlgorithm import VTKPythonAlgorithmBase`. We should not import from `vtk` directly, as this loads all modules. To load only necessary modules, we should import from `vtkmodules` instead.