### PR TITLE
Use PyPI OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,15 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyvista-xarray
+    permissions:
+      id-token: write # this permission is mandatory for trusted publishing
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -14,11 +21,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
-      - name: Build and Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          python -m build
-          twine upload --skip-existing dist/*
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,19 +26,7 @@ jobs:
       - name: Scooby Report
         run: python -c "import pvxarray;print(pvxarray.Report())"
       - name: Run Tests
-        run: |
-          coverage run -m pytest -v
-          coverage xml -o coverage.xml
-      - name: Stash coverage
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-${{ matrix.python-version }}.xml
-          path: coverage.xml
-      - uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
-          verbose: true
+        run: pytest -v
 
   # notebooks:
   #   runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # PyVista xarray
 
 [![PyPI](https://img.shields.io/pypi/v/pyvista-xarray.svg?logo=python&logoColor=white)](https://pypi.org/project/pyvista-xarray/)
-[![codecov](https://codecov.io/gh/pyvista/pyvista-xarray/branch/main/graph/badge.svg?token=4BSDVV0WOG)](https://codecov.io/gh/pyvista/pyvista-xarray)
 [![MyBinder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyvista/pyvista-xarray/HEAD)
 
 xarray DataArray accessors for PyVista to visualize datasets in 3D


### PR DESCRIPTION
## Summary

Migrate release workflow from PyPI API token auth (via `twine upload`) to OIDC Trusted Publishing using `pypa/gh-action-pypi-publish`. Removes reliance on `PYPI_API_TOKEN` and adds `permissions: id-token: write` plus `environment: pypi`.

## Next steps

- [ ] Add a Trusted Publisher on PyPI for this project: Account → Publishing → Add a new publisher (workflow: `release.yml`, environment: `pypi`).
- [ ] Add `pyvista-xarray` to the `pyvista` PyPI organization.
- [ ] After first successful OIDC release, delete the old PyPI API token and revoke the `PYPI_API_TOKEN` Actions secret.